### PR TITLE
[feat] Damage items on item preservation

### DIFF
--- a/src/main/java/red/jackf/lenientdeath/command/subcommand/CommandConfig.java
+++ b/src/main/java/red/jackf/lenientdeath/command/subcommand/CommandConfig.java
@@ -433,7 +433,6 @@ public class CommandConfig {
         ));
 
         root.then(makeVoidRecoveryNode());
-        root.then(makeLavaRecoveryNode());
 
         return root;
     }
@@ -456,29 +455,6 @@ public class CommandConfig {
                 WikiPage.ITEM_RESILIENCE,
                 config -> config.itemResilience.voidRecovery.announce,
                 (config, newValue) -> config.itemResilience.voidRecovery.announce = newValue
-        ));
-
-        return root;
-    }
-
-    private static LiteralArgumentBuilder<CommandSourceStack> makeLavaRecoveryNode() {
-        var root = Commands.literal("lavaRecovery");
-
-        root.then(makeEnum(
-                "mode",
-                "itemResilience.lavaRecovery.mode",
-                WikiPage.ITEM_RESILIENCE,
-                LenientDeathConfig.ItemResilience.LavaRecovery.Mode.class,
-                config -> config.itemResilience.lavaRecovery.mode,
-                (config, newValue) -> config.itemResilience.lavaRecovery.mode = newValue
-        ));
-
-        root.then(makeBoolean(
-                "announce",
-                "itemResilience.lavaRecovery.announce",
-                WikiPage.ITEM_RESILIENCE,
-                config -> config.itemResilience.lavaRecovery.announce,
-                (config, newValue) -> config.itemResilience.lavaRecovery.announce = newValue
         ));
 
         return root;

--- a/src/main/java/red/jackf/lenientdeath/command/subcommand/CommandConfig.java
+++ b/src/main/java/red/jackf/lenientdeath/command/subcommand/CommandConfig.java
@@ -433,7 +433,8 @@ public class CommandConfig {
         ));
 
         root.then(makeVoidRecoveryNode());
-        
+        root.then(makeLavaRecoveryNode());
+
         return root;
     }
 
@@ -455,6 +456,29 @@ public class CommandConfig {
                 WikiPage.ITEM_RESILIENCE,
                 config -> config.itemResilience.voidRecovery.announce,
                 (config, newValue) -> config.itemResilience.voidRecovery.announce = newValue
+        ));
+
+        return root;
+    }
+
+    private static LiteralArgumentBuilder<CommandSourceStack> makeLavaRecoveryNode() {
+        var root = Commands.literal("lavaRecovery");
+
+        root.then(makeEnum(
+                "mode",
+                "itemResilience.lavaRecovery.mode",
+                WikiPage.ITEM_RESILIENCE,
+                LenientDeathConfig.ItemResilience.LavaRecovery.Mode.class,
+                config -> config.itemResilience.lavaRecovery.mode,
+                (config, newValue) -> config.itemResilience.lavaRecovery.mode = newValue
+        ));
+
+        root.then(makeBoolean(
+                "announce",
+                "itemResilience.lavaRecovery.announce",
+                WikiPage.ITEM_RESILIENCE,
+                config -> config.itemResilience.lavaRecovery.announce,
+                (config, newValue) -> config.itemResilience.lavaRecovery.announce = newValue
         ));
 
         return root;
@@ -921,12 +945,60 @@ public class CommandConfig {
                 config -> config.preserveItemsOnDeath.randomizer.luckMultiplierFactor,
                 (config, newVal) -> config.preserveItemsOnDeath.randomizer.luckMultiplierFactor = newVal));
 
+        var itemdamage = Commands.literal("itemdamage")
+                .then(makeBoolean("enabled",
+                        "preserveItemsOnDeath.itemdamage.enabled",
+                        WikiPage.PRESERVE_ITEMS_ON_DEATH,
+                        config -> config.preserveItemsOnDeath.itemdamage.enabled,
+                        (config, newVal) -> config.preserveItemsOnDeath.itemdamage.enabled = newVal))
+                .then(makeIntRange("percentage",
+                        "preserveItemsOnDeath.itemdamage.percentage",
+                        WikiPage.PRESERVE_ITEMS_ON_DEATH,
+                        0,
+                        100,
+                        config -> config.preserveItemsOnDeath.itemdamage.percentage,
+                        (config, newVal) -> config.preserveItemsOnDeath.itemdamage.percentage = newVal))
+                .then(makeIntRange("baseDamagePercentage",
+                        "preserveItemsOnDeath.itemdamage.baseDamagePercentage",
+                        WikiPage.PRESERVE_ITEMS_ON_DEATH,
+                        0,
+                        100,
+                        config -> config.preserveItemsOnDeath.itemdamage.baseDamagePercentage,
+                        (config, newVal) -> config.preserveItemsOnDeath.itemdamage.baseDamagePercentage = newVal))
+                .then(makeIntRange("minimumItemHealth",
+                        "preserveItemsOnDeath.itemdamage.minimumItemHealth",
+                        WikiPage.PRESERVE_ITEMS_ON_DEATH,
+                        0,
+                        100,
+                        config -> config.preserveItemsOnDeath.itemdamage.minimumItemHealth,
+                        (config, newVal) -> config.preserveItemsOnDeath.itemdamage.minimumItemHealth = newVal))
+                .then(makeBoolean("percentageRandomness",
+                        "preserveItemsOnDeath.randomizer.percentageRandomness",
+                        WikiPage.PRESERVE_ITEMS_ON_DEATH,
+                        config -> config.preserveItemsOnDeath.itemdamage.percentageRandomness,
+                        (config, newVal) -> config.preserveItemsOnDeath.itemdamage.percentageRandomness = newVal))
+                .then(makeIntRange("randomizedPercentageMin",
+                        "preserveItemsOnDeath.itemdamage.randomizedPercentageMin",
+                        WikiPage.PRESERVE_ITEMS_ON_DEATH,
+                        0,
+                        100,
+                        config -> config.preserveItemsOnDeath.itemdamage.randomizedPercentageMin,
+                        (config, newVal) -> config.preserveItemsOnDeath.itemdamage.randomizedPercentageMin = newVal))
+                .then(makeIntRange("randomizedPercentageMax",
+                        "preserveItemsOnDeath.itemdamage.randomizedPercentageMax",
+                        WikiPage.PRESERVE_ITEMS_ON_DEATH,
+                        0,
+                        100,
+                        config -> config.preserveItemsOnDeath.itemdamage.randomizedPercentageMax,
+                        (config, newVal) -> config.preserveItemsOnDeath.itemdamage.randomizedPercentageMax = newVal));
+
         root.then(nbt);
         root.then(alwaysDropped);
         root.then(alwaysPreserved);
         root.then(trinkets);
         root.then(itemType);
         root.then(randomizer);
+        root.then(itemdamage);
 
         return root;
     }

--- a/src/main/java/red/jackf/lenientdeath/command/subcommand/CommandConfig.java
+++ b/src/main/java/red/jackf/lenientdeath/command/subcommand/CommandConfig.java
@@ -433,7 +433,7 @@ public class CommandConfig {
         ));
 
         root.then(makeVoidRecoveryNode());
-
+        
         return root;
     }
 
@@ -459,6 +459,7 @@ public class CommandConfig {
 
         return root;
     }
+
 
     private static LiteralArgumentBuilder<CommandSourceStack> createPresetsNode() {
         var root = Commands.literal("presets");

--- a/src/main/java/red/jackf/lenientdeath/config/LenientDeathConfig.java
+++ b/src/main/java/red/jackf/lenientdeath/config/LenientDeathConfig.java
@@ -322,6 +322,11 @@ public class LenientDeathConfig implements Config<LenientDeathConfig> {
                 that haven't been decided by other modules.""")
         public Randomizer randomizer = new Randomizer();
 
+        @Comment("""
+                Allows you to preserve items based on a random chance percentage. This is only applied to categories
+                that haven't been decided by other modules.""")
+        public ItemDamage itemdamage = new ItemDamage();
+
         public static class Nbt {
             @Comment("""
                     Whether preserving based off a certain item NBT tag should be enabled.
@@ -572,6 +577,55 @@ public class LenientDeathConfig implements Config<LenientDeathConfig> {
                     return this;
                 }
             }
+        }
+
+        public static class ItemDamage {
+            @Comment("""
+                    Whether preserving items should be damaged.
+                    Options: true, false
+                    Default: false""")
+            public boolean enabled = false;
+
+            @Comment(""" 
+                    The percentage chance that an item will take damage upon death. 
+                    This setting defines the likelihood that an item in the player's inventory will be damaged. 
+                    Default: 75 """)
+            public int percentage = 75;
+
+            @Comment(""" 
+                    The base damage percentage that an item should always receive upon death. 
+                    This ensures that items take a minimum amount of damage. 
+                    Default: 10 """)
+            public int baseDamagePercentage = 10;
+
+            @Comment("""
+                What minimum damage value should be maintained for a player's items upon death? This setting defines the minimum
+                health of an item. If set to 0, items can be completely destroyed.
+                Default: 10
+            """)
+            public int minimumItemHealth = 10;
+
+            @Comment("""
+                Enable randomness in the damage percentage of a player's items upon death. This modifier introduces variability,
+                ensuring that the damage percentage falls within a specified range rather than a fixed value.
+                Options: [true, false]
+                Default: true
+            """)
+            public boolean percentageRandomness = true;
+
+            @Comment("""
+                Minimum damage percentage for a player's items upon death when randomness is enabled.
+                This sets the lower bound for the variability.
+                Default: 15
+            """)
+            public int randomizedPercentageMin = 15;
+
+            @Comment("""
+                Maximum damage percentage for a player's items upon death when randomness is enabled.
+                This sets the upper bound for the variability.
+                Default: 40
+            """)
+            public int randomizedPercentageMax = 40;
         }
 
         public static class Randomizer {

--- a/src/main/java/red/jackf/lenientdeath/preserveitems/ItemDamage.java
+++ b/src/main/java/red/jackf/lenientdeath/preserveitems/ItemDamage.java
@@ -1,0 +1,55 @@
+package red.jackf.lenientdeath.preserveitems;
+
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+import red.jackf.lenientdeath.LenientDeath;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public class ItemDamage {
+
+    public static ItemStack applyItemDamage(ServerPlayer deathPlayer, ItemStack stack) {
+        var config = LenientDeath.CONFIG.instance().preserveItemsOnDeath.itemdamage;
+
+        //Item is not Damageable (ignoring)
+        if(!stack.isDamageableItem())
+            return stack;
+
+        int currentDamage = stack.getDamageValue(); // Placeholder for actual stack method
+        int maxDamage = stack.getMaxDamage();      // Placeholder for actual stack method
+
+        // Determine if the item will take damage based on the percentage chance
+        boolean willTakeDamage = ThreadLocalRandom.current().nextInt(0, 100) < config.percentage;
+
+        //Return the ItemStack without damaging it (ignoring)
+        if (!willTakeDamage) {
+            return stack;
+        }
+
+        // Calculate damage percentage
+        double damagePercentage = config.baseDamagePercentage;
+
+        // Apply randomization if enabled
+        if (config.percentageRandomness) {
+            double randomFactor = ThreadLocalRandom.current().nextDouble(config.randomizedPercentageMin, config.randomizedPercentageMax);
+            damagePercentage = config.baseDamagePercentage * (randomFactor / 100.0);
+        }
+
+        // Convert the damage percentage to actual damage
+        int newDamage = currentDamage + (int) ((damagePercentage / 100) * maxDamage);
+
+        // Ensure the new damage doesn't exceed the item's maximum or fall below the minimum threshold
+        newDamage = Math.min(newDamage, maxDamage - config.minimumItemHealth);
+
+        //If config.minimumItemHealth is <= 0 and the newDamage is or exceeds the maxDamage of an item, remove the ItemStack from the Player Inventory - which destroys the item.
+        if(config.minimumItemHealth <= 0 && newDamage >= maxDamage)
+        {
+            deathPlayer.getInventory().removeItem(stack);
+        }
+
+        // Update the stack's damage value
+        stack.setDamageValue(newDamage); // Placeholder for actual stack method
+
+        return stack;
+    }
+}


### PR DESCRIPTION
**Summary**
These additions allow for more nuanced control over item preservation and damage upon player death, providing configurable options for server administrators. If you need further details or have any questions, feel free to ask!

**Key Additions:**

Additions in `onlyDropIfNotSafe` Method:
- The method is modified to include a configuration check for preserving items on death and applying item damage.
- Introduced a new check that applies damage to items if the itemdamage configuration is enabled.

Configuration Class:
- Added a new ItemDamage configuration class with several customizable options for item damage mechanics upon death.

**Item Damage Logic:**
Introduced a new ItemDamage class that contains the logic for applying damage to items when a player dies. The class `ItemDamage` implements the logic for applying damage to items upon player death. The logic includes:

- Checking if the item is damageable.
- Determining if the item will take damage based on a percentage chance.
- Applying randomization to the damage percentage if enabled.
- Calculating the new damage value and ensuring it doesn't exceed specified thresholds.
- Removing the item from the player's inventory if it is completely destroyed (if `minimumItemHealth = 0`)

**Configurable Options**
1. enabled: Whether item damage on death is enabled.
2. percentage: The likelihood that an item will take damage upon death.
3. baseDamagePercentage: The base percentage of damage an item should always receive upon death.
4. minimumItemHealth: The minimum damage value to be maintained for a player's items upon death.
5. percentageRandomness: Whether randomness in the damage percentage is enabled.
6. randomizedPercentageMin: The minimum damage percentage when randomness is enabled.
7. randomizedPercentageMax: The maximum damage percentage when randomness is enabled.


The Wiki needs to be updated after this pull request.